### PR TITLE
Add food allergy, restriction, medicine allergy, medical condition, a…nd phobia options in multiple languages; enhance CardView and MakerView functionality 

### DIFF
--- a/src/lib/data/en.json
+++ b/src/lib/data/en.json
@@ -6,35 +6,58 @@
       "label": "Food allergies",
       "options": [
         { "id": 1, "label": "Peanuts" },
-        { "id": 2, "label": "Shellfish" }
+        { "id": 2, "label": "Shellfish" },
+        { "id": 3, "label": "Milk" },
+        { "id": 4, "label": "Eggs" },
+        { "id": 5, "label": "Wheat" },
+        { "id": 6, "label": "Soy" },
+        { "id": 7, "label": "Fish" }
       ]
     },
     "foodRestrictions": {
       "label": "Food restrictions",
       "options": [
         { "id": 10, "label": "Vegetarian" },
-        { "id": 11, "label": "Vegan" }
+        { "id": 11, "label": "Vegan" },
+        { "id": 12, "label": "Gluten-free" },
+        { "id": 13, "label": "Dairy-free" },
+        { "id": 14, "label": "Nut-free" },
+        { "id": 15, "label": "Halal" },
+        { "id": 16, "label": "Kosher" }
       ]
     },
     "medicineAllergies": {
       "label": "Medicine allergies",
       "options": [
         { "id": 20, "label": "Penicillin" },
-        { "id": 21, "label": "Ibuprofen" }
+        { "id": 21, "label": "Ibuprofen" },
+        { "id": 22, "label": "Aspirin" },
+        { "id": 23, "label": "Sulfa drugs" },
+        { "id": 24, "label": "Anesthesia" },
+        { "id": 25, "label": "Morphine" }
       ]
     },
     "medicalConditions": {
       "label": "Medical conditions",
       "options": [
         { "id": 30, "label": "Diabetes" },
-        { "id": 31, "label": "Asthma" }
+        { "id": 31, "label": "Asthma" },
+        { "id": 32, "label": "High blood pressure" },
+        { "id": 33, "label": "Heart condition" },
+        { "id": 34, "label": "Epilepsy" },
+        { "id": 35, "label": "Kidney disease" }
       ]
     },
     "phobias": {
       "label": "Phobias",
       "options": [
         { "id": 40, "label": "Needles" },
-        { "id": 41, "label": "Closed spaces" }
+        { "id": 41, "label": "Closed spaces" },
+        { "id": 42, "label": "Flying" },
+        { "id": 43, "label": "Heights" },
+        { "id": 44, "label": "Crowds" },
+        { "id": 45, "label": "Dogs" },
+        { "id": 46, "label": "Insects" }
       ]
     }
   }

--- a/src/lib/data/es.json
+++ b/src/lib/data/es.json
@@ -6,35 +6,58 @@
       "label": "Food allergies",
       "options": [
         { "id": 1, "label": "Cacahuetes" },
-        { "id": 2, "label": "Mariscos" }
+        { "id": 2, "label": "Mariscos" },
+        { "id": 3, "label": "Leche" },
+        { "id": 4, "label": "Huevos" },
+        { "id": 5, "label": "Trigo" },
+        { "id": 6, "label": "Soja" },
+        { "id": 7, "label": "Pescado" }
       ]
     },
     "foodRestrictions": {
       "label": "Food restrictions",
       "options": [
         { "id": 10, "label": "Vegetariano" },
-        { "id": 11, "label": "Vegano" }
+        { "id": 11, "label": "Vegano" },
+        { "id": 12, "label": "Sin gluten" },
+        { "id": 13, "label": "Sin lácteos" },
+        { "id": 14, "label": "Sin frutos secos" },
+        { "id": 15, "label": "Halal" },
+        { "id": 16, "label": "Kosher" }
       ]
     },
     "medicineAllergies": {
       "label": "Medicine allergies",
       "options": [
         { "id": 20, "label": "Penicilina" },
-        { "id": 21, "label": "Ibuprofeno" }
+        { "id": 21, "label": "Ibuprofeno" },
+        { "id": 22, "label": "Aspirina" },
+        { "id": 23, "label": "Sulfonamidas" },
+        { "id": 24, "label": "Anestesia" },
+        { "id": 25, "label": "Morfina" }
       ]
     },
     "medicalConditions": {
       "label": "Medical conditions",
       "options": [
         { "id": 30, "label": "Diabetes" },
-        { "id": 31, "label": "Asma" }
+        { "id": 31, "label": "Asma" },
+        { "id": 32, "label": "Hipertensión" },
+        { "id": 33, "label": "Enfermedad cardíaca" },
+        { "id": 34, "label": "Epilepsia" },
+        { "id": 35, "label": "Enfermedad renal" }
       ]
     },
     "phobias": {
       "label": "Phobias",
       "options": [
         { "id": 40, "label": "Agujas" },
-        { "id": 41, "label": "Espacios cerrados" }
+        { "id": 41, "label": "Espacios cerrados" },
+        { "id": 42, "label": "Volar" },
+        { "id": 43, "label": "Alturas" },
+        { "id": 44, "label": "Multitudes" },
+        { "id": 45, "label": "Perros" },
+        { "id": 46, "label": "Insectos" }
       ]
     }
   }

--- a/src/lib/data/zh-Hans.json
+++ b/src/lib/data/zh-Hans.json
@@ -6,35 +6,58 @@
       "label": "Food allergies",
       "options": [
         { "id": 1, "label": "花生" },
-        { "id": 2, "label": "贝类" }
+        { "id": 2, "label": "贝类" },
+        { "id": 3, "label": "牛奶" },
+        { "id": 4, "label": "鸡蛋" },
+        { "id": 5, "label": "小麦" },
+        { "id": 6, "label": "大豆" },
+        { "id": 7, "label": "鱼" }
       ]
     },
     "foodRestrictions": {
       "label": "Food restrictions",
       "options": [
         { "id": 10, "label": "素食" },
-        { "id": 11, "label": "全素" }
+        { "id": 11, "label": "全素" },
+        { "id": 12, "label": "无麸质" },
+        { "id": 13, "label": "无乳制品" },
+        { "id": 14, "label": "无坚果" },
+        { "id": 15, "label": "清真" },
+        { "id": 16, "label": "犹太洁食" }
       ]
     },
     "medicineAllergies": {
       "label": "Medicine allergies",
       "options": [
         { "id": 20, "label": "青霉素" },
-        { "id": 21, "label": "布洛芬" }
+        { "id": 21, "label": "布洛芬" },
+        { "id": 22, "label": "阿司匹林" },
+        { "id": 23, "label": "磺胺类药物" },
+        { "id": 24, "label": "麻醉" },
+        { "id": 25, "label": "吗啡" }
       ]
     },
     "medicalConditions": {
       "label": "Medical conditions",
       "options": [
         { "id": 30, "label": "糖尿病" },
-        { "id": 31, "label": "哮喘" }
+        { "id": 31, "label": "哮喘" },
+        { "id": 32, "label": "高血压" },
+        { "id": 33, "label": "心脏病" },
+        { "id": 34, "label": "癫痫" },
+        { "id": 35, "label": "肾脏疾病" }
       ]
     },
     "phobias": {
       "label": "Phobias",
       "options": [
         { "id": 40, "label": "针头" },
-        { "id": 41, "label": "密闭空间" }
+        { "id": 41, "label": "密闭空间" },
+        { "id": 42, "label": "飞行" },
+        { "id": 43, "label": "恐高" },
+        { "id": 44, "label": "人群" },
+        { "id": 45, "label": "狗" },
+        { "id": 46, "label": "昆虫" }
       ]
     }
   }

--- a/src/lib/data/zh-Hant.json
+++ b/src/lib/data/zh-Hant.json
@@ -6,35 +6,58 @@
       "label": "食物過敏",
       "options": [
         { "id": 1, "label": "花生" },
-        { "id": 2, "label": "貝類" }
+        { "id": 2, "label": "貝類" },
+        { "id": 3, "label": "牛奶" },
+        { "id": 4, "label": "雞蛋" },
+        { "id": 5, "label": "小麥" },
+        { "id": 6, "label": "大豆" },
+        { "id": 7, "label": "魚" }
       ]
     },
     "foodRestrictions": {
       "label": "飲食限制",
       "options": [
         { "id": 10, "label": "素食" },
-        { "id": 11, "label": "全素" }
+        { "id": 11, "label": "全素" },
+        { "id": 12, "label": "無麩質" },
+        { "id": 13, "label": "無乳製品" },
+        { "id": 14, "label": "無堅果" },
+        { "id": 15, "label": "清真" },
+        { "id": 16, "label": "猶太潔食" }
       ]
     },
     "medicineAllergies": {
       "label": "藥物過敏",
       "options": [
         { "id": 20, "label": "青黴素" },
-        { "id": 21, "label": "布洛芬" }
+        { "id": 21, "label": "布洛芬" },
+        { "id": 22, "label": "阿司匹林" },
+        { "id": 23, "label": "磺胺類藥物" },
+        { "id": 24, "label": "麻醉" },
+        { "id": 25, "label": "嗎啡" }
       ]
     },
     "medicalConditions": {
       "label": "醫療狀況",
       "options": [
         { "id": 30, "label": "糖尿病" },
-        { "id": 31, "label": "哮喘" }
+        { "id": 31, "label": "哮喘" },
+        { "id": 32, "label": "高血壓" },
+        { "id": 33, "label": "心臟病" },
+        { "id": 34, "label": "癲癇" },
+        { "id": 35, "label": "腎臟疾病" }
       ]
     },
     "phobias": {
       "label": "恐懼症",
       "options": [
         { "id": 40, "label": "針頭" },
-        { "id": 41, "label": "密閉空間" }
+        { "id": 41, "label": "密閉空間" },
+        { "id": 42, "label": "飛行" },
+        { "id": 43, "label": "恐高" },
+        { "id": 44, "label": "人群" },
+        { "id": 45, "label": "狗" },
+        { "id": 46, "label": "昆蟲" }
       ]
     }
   }

--- a/src/views/MakerView.svelte
+++ b/src/views/MakerView.svelte
@@ -85,8 +85,11 @@
     return englishData.categories[key].options;
   };
 
-  const getAvailableOptions = (key: CategoryKey): OptionEntry[] => {
-    const selected = new Set(selections[key]);
+  const getAvailableOptions = (
+    key: CategoryKey,
+    selectedItems: number[],
+  ): OptionEntry[] => {
+    const selected = new Set(selectedItems);
     return getCategoryOptions(key).filter((entry) => !selected.has(entry.id));
   };
 
@@ -116,7 +119,7 @@
       return;
     }
 
-    const match = getAvailableOptions(key).find(
+    const match = getAvailableOptions(key, selections[key]).find(
       (entry) => entry.label.toLowerCase() === rawValue.toLowerCase(),
     );
 
@@ -252,7 +255,10 @@
               />
               {#if showOptions[categoryItem.key]}
                 <div class="row__options" role="listbox">
-                  {#each getAvailableOptions(categoryItem.key) as option}
+                  {#each getAvailableOptions(
+                    categoryItem.key,
+                    selections[categoryItem.key],
+                  ) as option (option.id)}
                     <button
                       type="button"
                       class="row__option"


### PR DESCRIPTION
 Summary
- Expand card data across EN/ES/zh-Hans/zh-Hant with consistent IDs
- Make dropdown options update immediately after selection
- Render a second “reverse side” English card in Card view

 Issues
- #13 Add more data to JSON files
- #15 Items in dropdowns should reactively be removed from dropdown on-click
- #14 Make Card view show two cards (target + English reverse)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded data options for allergies, dietary restrictions, medicine allergies, medical conditions, and phobias across English, Spanish, Simplified Chinese, and Traditional Chinese
  * Implemented dual-card display showing target language selections with English reverse side for reference

* **Improvements**
  * Enhanced filtering logic for available options to exclude previously selected items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->