### PR TITLE
Feature/dropdown behavior fix

### DIFF
--- a/src/views/MakerView.svelte
+++ b/src/views/MakerView.svelte
@@ -85,9 +85,9 @@
     return englishData.categories[key].options;
   };
 
-  const getAvailableOptions = (key: CategoryKey): OptionEntry[] => {
-    const selected = new Set(selections[key]);
-    return getCategoryOptions(key).filter((entry) => !selected.has(entry.id));
+  const getAvailableOptions = (key: CategoryKey, currentSelections: typeof selections): OptionEntry[] => {
+      const selected = new Set(currentSelections[key]);
+      return getCategoryOptions(key).filter((entry) => !selected.has(entry.id));
   };
 
   const getLabel = (key: CategoryKey, id: number) => {
@@ -259,8 +259,8 @@
                     <button
                       type="button"
                       class="row__option"
-                      on:mousedown|preventDefault={() =>
-                        addSelectionFromOption(categoryItem.key, option)}
+                      on:mousedown|preventDefault 
+                      on:click={() => addSelectionFromOption(categoryItem.key, option)}
                     >
                       {option.label}
                     </button>

--- a/src/views/MakerView.svelte
+++ b/src/views/MakerView.svelte
@@ -229,6 +229,7 @@
           {/each}
         </div>
       </div>
+
       {#each categoryEntries as categoryItem}
         {#if enabledCategories.has(categoryItem.key)}
           {@const available = getAvailableOptions(categoryItem.key, selections)}
@@ -257,7 +258,7 @@
                   {#each available as option}
                     <button
                       type="button"
-                      class="row__option" 
+                      class="row__option"
                       on:mousedown|preventDefault={() =>
                         addSelectionFromOption(categoryItem.key, option)}
                     >

--- a/src/views/MakerView.svelte
+++ b/src/views/MakerView.svelte
@@ -229,9 +229,10 @@
           {/each}
         </div>
       </div>
-
       {#each categoryEntries as categoryItem}
         {#if enabledCategories.has(categoryItem.key)}
+          {@const available = getAvailableOptions(categoryItem.key, selections)}
+          {@const isEmpty = available.length === 0}
           <div class="maker__row">
             <label class="row__label" for={`input-${categoryItem.key}`}
               >{categoryItem.label}</label
@@ -241,8 +242,9 @@
                 id={`input-${categoryItem.key}`}
                 class="row__input"
                 type="text"
-                placeholder="Type to search and select"
+                placeholder={isEmpty ? "No more options" : "Type to search and select"}
                 list={`list-${categoryItem.key}`}
+                disabled={isEmpty}
                 bind:value={inputs[categoryItem.key]}
                 on:change={() => addSelection(categoryItem.key)}
                 on:focus={() =>
@@ -250,15 +252,13 @@
                 on:blur={() =>
                   (showOptions = { ...showOptions, [categoryItem.key]: false })}
               />
-              {#if showOptions[categoryItem.key]}
+              {#if showOptions[categoryItem.key] && !isEmpty}
                 <div class="row__options" role="listbox">
-                  {#each getAvailableOptions(categoryItem.key) as option}
+                  {#each available as option}
                     <button
                       type="button"
-                      class="row__option"
+                      class="row__option" 
                       on:mousedown|preventDefault={() =>
-                        addSelectionFromOption(categoryItem.key, option)}
-                      on:click={() =>
                         addSelectionFromOption(categoryItem.key, option)}
                     >
                       {option.label}


### PR DESCRIPTION
Fixes #15 

Makes selecting something from the dropdown remove it from the displayed options without having to reselect the dropdown. Also makes the dropdown not appear if there are no more options to select.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category selection now precomputes per-category availability for faster, more accurate feedback.
  * Input fields show "No more options" and become disabled when a category is exhausted.
  * Dropdowns only open when options are available, preventing empty option lists.
  * Option clicks reliably add selections based on the current availability state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->